### PR TITLE
Adds chainId to Ganache cli options.

### DIFF
--- a/scripts/ganache.sh
+++ b/scripts/ganache.sh
@@ -5,7 +5,8 @@ rm -rf /tmp/yarn*
 yarn ganache-cli \
   --host 127.0.0.1 \
   --port 7545 \
-  -i 5777 \
+  --networkId 5777 \
+  --chainId 5777 \
   --gasLimit 0x59A5380 \
   --gasPrice 1 \
   --defaultBalanceEther 10000 \


### PR DESCRIPTION
When using MetaMask and trying to use 5777 as the Chain ID it returns `The endpoint returned a different chain ID: 1337`. This is because by default Ganache sets the Chain ID to 1337.

This change sets the Chain ID to 5777 explicitly.